### PR TITLE
The data of the relationship is a required resource identfier

### DIFF
--- a/src/examples/relationship.py
+++ b/src/examples/relationship.py
@@ -1,0 +1,52 @@
+from typing import Optional
+
+from pydantic import BaseModel
+from pydantic import Field
+
+from pydanja import DANJARelationship
+from pydanja import DANJATopLevel
+
+
+class Author(BaseModel):
+    id: Optional[str] = Field(
+        json_schema_extra={
+            "resource_id": True
+        }
+    )
+    name: str
+
+    def from_basemodel(self):
+        return DANJATopLevel.from_basemodel(self)
+
+
+class Article(BaseModel):
+    id: Optional[str] = Field(
+        json_schema_extra={
+            "resource_id": True
+        }
+    )
+    title: str
+    author: Author
+
+    def from_basemodel(self):
+        toplevel = DANJATopLevel.from_basemodel(self)
+        toplevel_author = self.author.from_basemodel()
+        rel = DANJARelationship.from_danjaresource(toplevel_author)
+
+        # replaces pop key by relationship (
+        toplevel.resource.pop('author')
+        toplevel.data.relationships = {
+            'author': rel
+        }
+
+        # set top level resource in included
+        toplevel.included = {"author": toplevel_author}
+        return toplevel
+
+
+if __name__ == '__main__':
+    author = Author(id='0', name="Shakespeare")
+    article = Article(id='0', title="Romeo is dead", author=author)
+
+    toplevel_article = article.from_basemodel()
+    print(toplevel_article.model_dump())

--- a/src/pydanja/__init__.py
+++ b/src/pydanja/__init__.py
@@ -1,6 +1,7 @@
 from typing import Generic, TypeVar, Optional, Dict, Any, List, Union
 
 from pydantic import BaseModel
+from pydantic.networks import AnyUrl
 
 from .openapi import danja_openapi
 
@@ -37,7 +38,7 @@ class ResourceResolver():
 
 class DANJALink(BaseModel):
     """JSON:API Link"""
-    href: str
+    href: Union[str, AnyUrl]
     rel: Optional[str] = None
     describedby: Optional[str] = None
     title: Optional[str] = None
@@ -74,7 +75,7 @@ class DANJAResourceIdentifier(BaseModel):
 
 class DANJARelationship(BaseModel, ResourceResolver):
     """JSON:API Relationship"""
-    links: Optional[Dict[str, Union[str, DANJALink, None]]] = None
+    links: Optional[Dict[str, Union[str, AnyUrl, DANJALink, None]]] = None
     data: DANJAResourceIdentifier
     meta: Optional[Dict[str, Any]] = None
 

--- a/src/pydanja/__init__.py
+++ b/src/pydanja/__init__.py
@@ -6,9 +6,8 @@ from pydantic.networks import AnyUrl
 from .openapi import danja_openapi
 
 __all__ = [
+    "DANJATopLevel",
     "DANJAResource",
-    "DANJAResource",
-    "DANJAResourceList",
     "DANJALink",
     "DANJAError",
     "DANJAErrorList",
@@ -63,11 +62,11 @@ class DANJAResourceIdentifier(BaseModel):
     @classmethod
     def from_danjaresource(
             cls,
-            resource: "DANJAResource",
+            resource: Union["DANJATopLevel", "DANJAResource"],
     ) -> "DANJAResourceIdentifier":
         values = {
-            "type": resource.type,
-            "id": resource.id,
+            "type": resource.data.type,
+            "id": resource.data.id,
         }
 
         return DANJAResourceIdentifier(**values)
@@ -104,7 +103,7 @@ class DANJARelationship(BaseModel, ResourceResolver):
     @classmethod
     def from_danjaresource(
             cls,
-            resource: "DANJAResource",
+            resource: Union["DANJATopLevel", "DANJAResource"],
     ) -> "DANJARelationship":
         identifier = DANJAResourceIdentifier.from_danjaresource(resource)
         return DANJARelationship(data=identifier)
@@ -178,7 +177,7 @@ class DANJATopLevel(BaseModel, ResourceResolver, Generic[ResourceType]):
             values = {
                 "type": resource_name,
                 "lid": None,
-                "attributes": resource
+                "attributes": resource.model_dump(by_alias=True)
             }
 
             id_value = object.__getattribute__(resource, resource_id)
@@ -223,7 +222,7 @@ class DANJATopLevel(BaseModel, ResourceResolver, Generic[ResourceType]):
                     values = {
                         "type": resource_name,
                         "lid": None,
-                        "attributes": sub_resource
+                        "attributes": sub_resource.model_dump(by_alias=True)
                     }
                     id_value = object.__getattribute__(sub_resource, resource_id)
                     if id_value:

--- a/src/pydanja/__init__.py
+++ b/src/pydanja/__init__.py
@@ -63,7 +63,7 @@ class DANJAResourceIdentifier(BaseModel):
     def from_danjaresource(
             cls,
             resource: "DANJAResource",
-    ) -> "DANJARelationship":
+    ) -> "DANJAResourceIdentifier":
         values = {
             "type": resource.data.type,
             "id": resource.data.id,

--- a/src/pydanja/__init__.py
+++ b/src/pydanja/__init__.py
@@ -227,17 +227,19 @@ class DANJAResourceList(BaseModel, ResourceResolver, Generic[ResourceType]):
                     if not resource_id:
                         raise Exception(f"No fields defined in {resource_name}")
 
-            data: List[DANJASingleResource] = []
-            for sub_resource in resources:
-                values = {
-                    "type": resource_name,
-                    "lid": None,
-                    "attributes": sub_resource
-                }
-                id_value = object.__getattribute__(sub_resource, resource_id)
-                if id_value:
-                    values["id"] = str(id_value)
-                data.append(DANJASingleResource(**values))
+                data: List[DANJASingleResource] = []
+                for sub_resource in resources:
+                    values = {
+                        "type": resource_name,
+                        "lid": None,
+                        "attributes": sub_resource
+                    }
+                    id_value = object.__getattribute__(sub_resource, resource_id)
+                    if id_value:
+                        values["id"] = str(id_value)
+                    data.append(DANJASingleResource(**values))
+            else:
+                data = []
 
             return cls(data=data)
         except AttributeError:

--- a/tests/fixtures/multiple_resource_with_id.json
+++ b/tests/fixtures/multiple_resource_with_id.json
@@ -4,8 +4,17 @@
             "description": "JSON:API Link",
             "properties": {
                 "href": {
-                    "title": "Href",
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "format": "uri",
+                            "minLength": 1,
+                            "type": "string"
+                        }
+                    ],
+                    "title": "Href"
                 },
                 "rel": {
                     "anyOf": [
@@ -95,6 +104,11 @@
                             "additionalProperties": {
                                 "anyOf": [
                                     {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "format": "uri",
+                                        "minLength": 1,
                                         "type": "string"
                                     },
                                     {

--- a/tests/fixtures/multiple_resource_with_id.json
+++ b/tests/fixtures/multiple_resource_with_id.json
@@ -115,32 +115,7 @@
                     "title": "Links"
                 },
                 "data": {
-                    "anyOf": [
-                        {
-                            "additionalProperties": {
-                                "anyOf": [
-                                    {
-                                        "$ref": "#/$defs/DANJAResourceIdentifier"
-                                    },
-                                    {
-                                        "items": {
-                                            "$ref": "#/$defs/DANJAResourceIdentifier"
-                                        },
-                                        "type": "array"
-                                    },
-                                    {
-                                        "type": "null"
-                                    }
-                                ]
-                            },
-                            "type": "object"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null,
-                    "title": "Data"
+                    "$ref": "#/$defs/DANJAResourceIdentifier"
                 },
                 "meta": {
                     "anyOf": [
@@ -155,6 +130,9 @@
                     "title": "Meta"
                 }
             },
+            "required": [
+                "data"
+            ],
             "title": "DANJARelationship",
             "type": "object"
         },

--- a/tests/fixtures/multiple_resource_with_id.json
+++ b/tests/fixtures/multiple_resource_with_id.json
@@ -167,7 +167,7 @@
             "title": "DANJAResourceIdentifier",
             "type": "object"
         },
-        "DANJASingleResource": {
+        "DANJAResource": {
             "description": "A single resource. The only JSON:API required field is type",
             "properties": {
                 "id": {
@@ -245,18 +245,25 @@
                 "type",
                 "attributes"
             ],
-            "title": "DANJASingleResource",
+            "title": "DANJAResource",
             "type": "object"
         }
     },
-    "description": "JSON:API base for a list of resources",
+    "description": "JSON:API base for a top level resource",
     "properties": {
         "data": {
-            "items": {
-                "$ref": "#/$defs/DANJASingleResource"
-            },
-            "title": "Data",
-            "type": "array"
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/DANJAResource"
+                },
+                {
+                    "items": {
+                        "$ref": "#/$defs/DANJAResource"
+                    },
+                    "type": "array"
+                }
+            ],
+            "title": "Data"
         },
         "links": {
             "anyOf": [
@@ -299,7 +306,7 @@
             "anyOf": [
                 {
                     "items": {
-                        "$ref": "#/$defs/DANJASingleResource"
+                        "$ref": "#/$defs/DANJAResource"
                     },
                     "type": "array"
                 },
@@ -314,6 +321,6 @@
     "required": [
         "data"
     ],
-    "title": "DANJAResourceList",
+    "title": "DANJATopLevel",
     "type": "object"
 }

--- a/tests/fixtures/multiple_resource_without_id.json
+++ b/tests/fixtures/multiple_resource_without_id.json
@@ -4,8 +4,17 @@
             "description": "JSON:API Link",
             "properties": {
                 "href": {
-                    "title": "Href",
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "format": "uri",
+                            "minLength": 1,
+                            "type": "string"
+                        }
+                    ],
+                    "title": "Href"
                 },
                 "rel": {
                     "anyOf": [
@@ -95,6 +104,11 @@
                             "additionalProperties": {
                                 "anyOf": [
                                     {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "format": "uri",
+                                        "minLength": 1,
                                         "type": "string"
                                     },
                                     {

--- a/tests/fixtures/multiple_resource_without_id.json
+++ b/tests/fixtures/multiple_resource_without_id.json
@@ -115,32 +115,7 @@
                     "title": "Links"
                 },
                 "data": {
-                    "anyOf": [
-                        {
-                            "additionalProperties": {
-                                "anyOf": [
-                                    {
-                                        "$ref": "#/$defs/DANJAResourceIdentifier"
-                                    },
-                                    {
-                                        "items": {
-                                            "$ref": "#/$defs/DANJAResourceIdentifier"
-                                        },
-                                        "type": "array"
-                                    },
-                                    {
-                                        "type": "null"
-                                    }
-                                ]
-                            },
-                            "type": "object"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null,
-                    "title": "Data"
+                    "$ref": "#/$defs/DANJAResourceIdentifier"
                 },
                 "meta": {
                     "anyOf": [
@@ -155,6 +130,9 @@
                     "title": "Meta"
                 }
             },
+            "required": [
+                "data"
+            ],
             "title": "DANJARelationship",
             "type": "object"
         },

--- a/tests/fixtures/multiple_resource_without_id.json
+++ b/tests/fixtures/multiple_resource_without_id.json
@@ -167,7 +167,7 @@
             "title": "DANJAResourceIdentifier",
             "type": "object"
         },
-        "DANJASingleResource": {
+        "DANJAResource": {
             "description": "A single resource. The only JSON:API required field is type",
             "properties": {
                 "id": {
@@ -245,18 +245,25 @@
                 "type",
                 "attributes"
             ],
-            "title": "DANJASingleResource",
+            "title": "DANJAResource",
             "type": "object"
         }
     },
-    "description": "JSON:API base for a list of resources",
+    "description": "JSON:API base for a top level resource",
     "properties": {
         "data": {
-            "items": {
-                "$ref": "#/$defs/DANJASingleResource"
-            },
-            "title": "Data",
-            "type": "array"
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/DANJAResource"
+                },
+                {
+                    "items": {
+                        "$ref": "#/$defs/DANJAResource"
+                    },
+                    "type": "array"
+                }
+            ],
+            "title": "Data"
         },
         "links": {
             "anyOf": [
@@ -299,7 +306,7 @@
             "anyOf": [
                 {
                     "items": {
-                        "$ref": "#/$defs/DANJASingleResource"
+                        "$ref": "#/$defs/DANJAResource"
                     },
                     "type": "array"
                 },
@@ -314,6 +321,6 @@
     "required": [
         "data"
     ],
-    "title": "DANJAResourceList",
+    "title": "DANJATopLevel",
     "type": "object"
 }

--- a/tests/fixtures/single_resource_with_id.json
+++ b/tests/fixtures/single_resource_with_id.json
@@ -4,8 +4,17 @@
             "description": "JSON:API Link",
             "properties": {
                 "href": {
-                    "title": "Href",
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "format": "uri",
+                            "minLength": 1,
+                            "type": "string"
+                        }
+                    ],
+                    "title": "Href"
                 },
                 "rel": {
                     "anyOf": [
@@ -95,6 +104,11 @@
                             "additionalProperties": {
                                 "anyOf": [
                                     {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "format": "uri",
+                                        "minLength": 1,
                                         "type": "string"
                                     },
                                     {

--- a/tests/fixtures/single_resource_with_id.json
+++ b/tests/fixtures/single_resource_with_id.json
@@ -167,7 +167,7 @@
             "title": "DANJAResourceIdentifier",
             "type": "object"
         },
-        "DANJASingleResource": {
+        "DANJAResource": {
             "description": "A single resource. The only JSON:API required field is type",
             "properties": {
                 "id": {
@@ -245,14 +245,25 @@
                 "type",
                 "attributes"
             ],
-            "title": "DANJASingleResource",
+            "title": "DANJAResource",
             "type": "object"
         }
     },
-    "description": "JSON:API base for a single resource",
+    "description": "JSON:API base for a top level resource",
     "properties": {
         "data": {
-            "$ref": "#/$defs/DANJASingleResource"
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/DANJAResource"
+                },
+                {
+                    "items": {
+                        "$ref": "#/$defs/DANJAResource"
+                    },
+                    "type": "array"
+                }
+            ],
+            "title": "Data"
         },
         "links": {
             "anyOf": [
@@ -295,7 +306,7 @@
             "anyOf": [
                 {
                     "items": {
-                        "type": "object"
+                        "$ref": "#/$defs/DANJAResource"
                     },
                     "type": "array"
                 },
@@ -310,6 +321,6 @@
     "required": [
         "data"
     ],
-    "title": "DANJAResource",
+    "title": "DANJATopLevel",
     "type": "object"
 }

--- a/tests/fixtures/single_resource_with_id.json
+++ b/tests/fixtures/single_resource_with_id.json
@@ -115,32 +115,7 @@
                     "title": "Links"
                 },
                 "data": {
-                    "anyOf": [
-                        {
-                            "additionalProperties": {
-                                "anyOf": [
-                                    {
-                                        "$ref": "#/$defs/DANJAResourceIdentifier"
-                                    },
-                                    {
-                                        "items": {
-                                            "$ref": "#/$defs/DANJAResourceIdentifier"
-                                        },
-                                        "type": "array"
-                                    },
-                                    {
-                                        "type": "null"
-                                    }
-                                ]
-                            },
-                            "type": "object"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null,
-                    "title": "Data"
+                    "$ref": "#/$defs/DANJAResourceIdentifier"
                 },
                 "meta": {
                     "anyOf": [
@@ -155,6 +130,9 @@
                     "title": "Meta"
                 }
             },
+            "required": [
+                "data"
+            ],
             "title": "DANJARelationship",
             "type": "object"
         },

--- a/tests/fixtures/single_resource_without_id.json
+++ b/tests/fixtures/single_resource_without_id.json
@@ -4,8 +4,17 @@
             "description": "JSON:API Link",
             "properties": {
                 "href": {
-                    "title": "Href",
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "format": "uri",
+                            "minLength": 1,
+                            "type": "string"
+                        }
+                    ],
+                    "title": "Href"
                 },
                 "rel": {
                     "anyOf": [
@@ -95,6 +104,11 @@
                             "additionalProperties": {
                                 "anyOf": [
                                     {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "format": "uri",
+                                        "minLength": 1,
                                         "type": "string"
                                     },
                                     {

--- a/tests/fixtures/single_resource_without_id.json
+++ b/tests/fixtures/single_resource_without_id.json
@@ -167,7 +167,7 @@
             "title": "DANJAResourceIdentifier",
             "type": "object"
         },
-        "DANJASingleResource": {
+        "DANJAResource": {
             "description": "A single resource. The only JSON:API required field is type",
             "properties": {
                 "id": {
@@ -245,14 +245,25 @@
                 "type",
                 "attributes"
             ],
-            "title": "DANJASingleResource",
+            "title": "DANJAResource",
             "type": "object"
         }
     },
-    "description": "JSON:API base for a single resource",
+    "description": "JSON:API base for a top level resource",
     "properties": {
         "data": {
-            "$ref": "#/$defs/DANJASingleResource"
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/DANJAResource"
+                },
+                {
+                    "items": {
+                        "$ref": "#/$defs/DANJAResource"
+                    },
+                    "type": "array"
+                }
+            ],
+            "title": "Data"
         },
         "links": {
             "anyOf": [
@@ -295,7 +306,7 @@
             "anyOf": [
                 {
                     "items": {
-                        "type": "object"
+                        "$ref": "#/$defs/DANJAResource"
                     },
                     "type": "array"
                 },
@@ -310,6 +321,6 @@
     "required": [
         "data"
     ],
-    "title": "DANJAResource",
+    "title": "DANJATopLevel",
     "type": "object"
 }

--- a/tests/fixtures/single_resource_without_id.json
+++ b/tests/fixtures/single_resource_without_id.json
@@ -115,32 +115,7 @@
                     "title": "Links"
                 },
                 "data": {
-                    "anyOf": [
-                        {
-                            "additionalProperties": {
-                                "anyOf": [
-                                    {
-                                        "$ref": "#/$defs/DANJAResourceIdentifier"
-                                    },
-                                    {
-                                        "items": {
-                                            "$ref": "#/$defs/DANJAResourceIdentifier"
-                                        },
-                                        "type": "array"
-                                    },
-                                    {
-                                        "type": "null"
-                                    }
-                                ]
-                            },
-                            "type": "object"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null,
-                    "title": "Data"
+                    "$ref": "#/$defs/DANJAResourceIdentifier"
                 },
                 "meta": {
                     "anyOf": [
@@ -155,6 +130,9 @@
                     "title": "Meta"
                 }
             },
+            "required": [
+                "data"
+            ],
             "title": "DANJARelationship",
             "type": "object"
         },

--- a/tests/test_resource_creation.py
+++ b/tests/test_resource_creation.py
@@ -1,9 +1,11 @@
-import pytest
 import json
-from typing import Optional
 from pathlib import Path
-from pydanja import DANJAResource, DANJATopLevel
+from typing import Optional
+
+import pytest
 from pydantic import BaseModel, Field
+
+from pydanja import DANJATopLevel
 
 
 class FixtureTestType(BaseModel):
@@ -47,10 +49,10 @@ def test_it_creates_a_container_from_base_model_with_id(resource):
     schema = new_resource.model_json_schema()
 
     # Check schema
-    assert(schema == resource)
+    assert (schema == resource)
 
     # Check resource data
-    assert(new_resource.resource == basemodel_instance)
+    assert (new_resource.resource == basemodel_instance)
 
 
 @pytest.mark.parametrize("resource", ["single_resource_without_id.json"], indirect=True)
@@ -71,10 +73,10 @@ def test_it_creates_a_container_from_base_model_without_id(resource):
     schema = new_resource.model_json_schema()
 
     # Check schema
-    assert(schema == resource)
+    assert (schema == resource)
 
     # Check resource data
-    assert(new_resource.resource == basemodel_instance)
+    assert (new_resource.resource == basemodel_instance)
 
 
 @pytest.mark.parametrize("resource", ["multiple_resource_with_id.json"], indirect=True)
@@ -103,10 +105,10 @@ def test_it_creates_a_container_list_from_base_model_with_id(resource):
     schema = new_resources.model_json_schema()
 
     # Check schema
-    assert(schema == resource)
+    assert (schema == resource)
 
     # Check resource data
-    assert(len(new_resources.resource) == len(basemodel_instances))
+    assert (len(new_resources.resource) == len(basemodel_instances))
 
 
 @pytest.mark.parametrize("resource", ["multiple_resource_without_id.json"], indirect=True)
@@ -133,7 +135,7 @@ def test_it_creates_a_container_list_from_base_model_without_id(resource):
     schema = new_resources.model_json_schema()
 
     # Check schema
-    assert(schema == resource)
+    assert (schema == resource)
 
     # Check resource data
-    assert(len(new_resources.resource) == len(basemodel_instances))
+    assert (len(new_resources.resource) == len(basemodel_instances))

--- a/tests/test_resource_creation.py
+++ b/tests/test_resource_creation.py
@@ -2,7 +2,7 @@ import pytest
 import json
 from typing import Optional
 from pathlib import Path
-from pydanja import DANJAResource, DANJAResourceList
+from pydanja import DANJAResource, DANJATopLevel
 from pydantic import BaseModel, Field
 
 
@@ -42,7 +42,7 @@ def test_it_creates_a_container_from_base_model_with_id(resource):
     )
 
     # Create the JSON:API container
-    new_resource = DANJAResource.from_basemodel(basemodel_instance)
+    new_resource = DANJATopLevel.from_basemodel(basemodel_instance)
 
     schema = new_resource.model_json_schema()
 
@@ -66,7 +66,7 @@ def test_it_creates_a_container_from_base_model_without_id(resource):
     )
 
     # Create the JSON:API container
-    new_resource = DANJAResource.from_basemodel(basemodel_instance)
+    new_resource = DANJATopLevel.from_basemodel(basemodel_instance)
 
     schema = new_resource.model_json_schema()
 
@@ -98,7 +98,7 @@ def test_it_creates_a_container_list_from_base_model_with_id(resource):
     ]
 
     # Create the JSON:API container
-    new_resources = DANJAResourceList.from_basemodel_list(basemodel_instances)
+    new_resources = DANJATopLevel.from_basemodel_list(basemodel_instances)
 
     schema = new_resources.model_json_schema()
 
@@ -106,7 +106,7 @@ def test_it_creates_a_container_list_from_base_model_with_id(resource):
     assert(schema == resource)
 
     # Check resource data
-    assert(len(new_resources.resources) == len(basemodel_instances))
+    assert(len(new_resources.resource) == len(basemodel_instances))
 
 
 @pytest.mark.parametrize("resource", ["multiple_resource_without_id.json"], indirect=True)
@@ -128,7 +128,7 @@ def test_it_creates_a_container_list_from_base_model_without_id(resource):
     ]
 
     # Create the JSON:API container
-    new_resources = DANJAResourceList.from_basemodel_list(basemodel_instances)
+    new_resources = DANJATopLevel.from_basemodel_list(basemodel_instances)
 
     schema = new_resources.model_json_schema()
 
@@ -136,4 +136,4 @@ def test_it_creates_a_container_list_from_base_model_without_id(resource):
     assert(schema == resource)
 
     # Check resource data
-    assert(len(new_resources.resources) == len(basemodel_instances))
+    assert(len(new_resources.resource) == len(basemodel_instances))


### PR DESCRIPTION
In the doc:
```
    "relationships": {
      "author": {
        "links": {
          "self": "http://example.com/articles/1/relationships/author",
          "related": "http://example.com/articles/1/author"
        },
        "data": { "type": "people", "id": "9" }
      },
```
the resources may be provided in the `included` top level structure

I added also functions to create relationship from basemodel

<!-- readthedocs-preview pydanja start -->
----
:books: Documentation preview :books:: https://pydanja--2.org.readthedocs.build/en/2/

<!-- readthedocs-preview pydanja end -->