### PR TITLE
Fix Error Source Structure

### DIFF
--- a/src/pydanja/__init__.py
+++ b/src/pydanja/__init__.py
@@ -1,6 +1,6 @@
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 from pydantic.functional_validators import ModelWrapValidatorHandler
-from typing import Generic, TypeVar, Optional, Any, Union
+from typing import Any, Generic, Optional, TypeVar, Union
 from typing_extensions import Self
 from copy import deepcopy
 from .openapi import danja_openapi
@@ -31,9 +31,12 @@ class DANJALink(BaseModel):
 
 class DANJASource(BaseModel):
     """JSON:API Source"""
-    pointer: str
-    parameter: str
-    header: str
+
+    model_config = ConfigDict(extra="forbid")
+
+    pointer: Optional[str] = None
+    parameter: Optional[str] = None
+    header: Optional[str] = None
 
 
 class DANJAResourceIdentifier(BaseModel):
@@ -52,13 +55,16 @@ class DANJARelationship(BaseModel):
 
 class DANJAError(BaseModel):
     """JSON:API Error object"""
+
+    model_config = ConfigDict(extra="forbid")
+
     id: Optional[str] = None
     links: Optional[dict[str, Union[str, DANJALink, None]]] = None
     status: Optional[str] = None
     code: Optional[str] = None
     title: Optional[str] = None
     detail: Optional[str] = None
-    source: Optional[dict[str, DANJASource]] = None
+    source: Optional[DANJASource] = None
     meta: Optional[dict[str, Any]] = None
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,15 @@
+import pytest
+from pydantic import ValidationError
+
+from pydanja import DANJAError, DANJASource
+
+
+def test_error_with_source():
+    DANJAError.model_validate({"source": {"pointer": "/"}})
+    with pytest.raises(ValidationError) as exc:
+        DANJAError(source={"str": DANJASource(pointer="/")}).model_dump()
+    errors = exc.value.errors()
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["type"] == "extra_forbidden"
+    assert error["loc"] == ("source", "str")


### PR DESCRIPTION
The definition of a source in an error was incorrect.

[Definition](https://jsonapi.org/format/#error-objects)
Examples [1](https://jsonapi.org/examples/#error-objects-basics) [2](https://jsonapi.org/examples/#error-objects-multiple-errors) [etc](https://jsonapi.org/examples/#error-objects).

I also set the model config extra to forbid so it won't ignore the previously invalid structure.

<!-- readthedocs-preview pydanja start -->
----
📚 Documentation preview 📚: https://pydanja--7.org.readthedocs.build/en/7/

<!-- readthedocs-preview pydanja end -->