### PR TITLE
Fix: Relationship data attribute typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,6 @@ dev = [
     "sphinx>=7.1.2",
     "ruff>=0.8.1",
 ]
+
+[tool.pytest.ini_options]
+pythonpath = [".", "src"]

--- a/tests/fixtures/multiple_resource_with_id.json
+++ b/tests/fixtures/multiple_resource_with_id.json
@@ -118,23 +118,13 @@
                 "data": {
                     "anyOf": [
                         {
-                            "additionalProperties": {
-                                "anyOf": [
-                                    {
-                                        "$ref": "#/$defs/DANJAResourceIdentifier"
-                                    },
-                                    {
-                                        "items": {
-                                            "$ref": "#/$defs/DANJAResourceIdentifier"
-                                        },
-                                        "type": "array"
-                                    },
-                                    {
-                                        "type": "null"
-                                    }
-                                ]
+                            "$ref": "#/$defs/DANJAResourceIdentifier"
+                        },
+                        {
+                            "items": {
+                                "$ref": "#/$defs/DANJAResourceIdentifier"
                             },
-                            "type": "object"
+                            "type": "array"
                         },
                         {
                             "type": "null"
@@ -182,6 +172,19 @@
                     ],
                     "default": null,
                     "title": "Lid"
+                },
+                "meta": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": true,
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Meta"
                 }
             },
             "required": [

--- a/tests/fixtures/multiple_resource_without_id.json
+++ b/tests/fixtures/multiple_resource_without_id.json
@@ -118,23 +118,13 @@
                 "data": {
                     "anyOf": [
                         {
-                            "additionalProperties": {
-                                "anyOf": [
-                                    {
-                                        "$ref": "#/$defs/DANJAResourceIdentifier"
-                                    },
-                                    {
-                                        "items": {
-                                            "$ref": "#/$defs/DANJAResourceIdentifier"
-                                        },
-                                        "type": "array"
-                                    },
-                                    {
-                                        "type": "null"
-                                    }
-                                ]
+                            "$ref": "#/$defs/DANJAResourceIdentifier"
+                        },
+                        {
+                            "items": {
+                                "$ref": "#/$defs/DANJAResourceIdentifier"
                             },
-                            "type": "object"
+                            "type": "array"
                         },
                         {
                             "type": "null"
@@ -182,6 +172,19 @@
                     ],
                     "default": null,
                     "title": "Lid"
+                },
+                "meta": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": true,
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Meta"
                 }
             },
             "required": [

--- a/tests/fixtures/single_resource_with_id.json
+++ b/tests/fixtures/single_resource_with_id.json
@@ -118,23 +118,13 @@
                 "data": {
                     "anyOf": [
                         {
-                            "additionalProperties": {
-                                "anyOf": [
-                                    {
-                                        "$ref": "#/$defs/DANJAResourceIdentifier"
-                                    },
-                                    {
-                                        "items": {
-                                            "$ref": "#/$defs/DANJAResourceIdentifier"
-                                        },
-                                        "type": "array"
-                                    },
-                                    {
-                                        "type": "null"
-                                    }
-                                ]
+                            "$ref": "#/$defs/DANJAResourceIdentifier"
+                        },
+                        {
+                            "items": {
+                                "$ref": "#/$defs/DANJAResourceIdentifier"
                             },
-                            "type": "object"
+                            "type": "array"
                         },
                         {
                             "type": "null"
@@ -182,6 +172,19 @@
                     ],
                     "default": null,
                     "title": "Lid"
+                },
+                "meta": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": true,
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Meta"
                 }
             },
             "required": [

--- a/tests/fixtures/single_resource_without_id.json
+++ b/tests/fixtures/single_resource_without_id.json
@@ -118,23 +118,13 @@
                 "data": {
                     "anyOf": [
                         {
-                            "additionalProperties": {
-                                "anyOf": [
-                                    {
-                                        "$ref": "#/$defs/DANJAResourceIdentifier"
-                                    },
-                                    {
-                                        "items": {
-                                            "$ref": "#/$defs/DANJAResourceIdentifier"
-                                        },
-                                        "type": "array"
-                                    },
-                                    {
-                                        "type": "null"
-                                    }
-                                ]
+                            "$ref": "#/$defs/DANJAResourceIdentifier"
+                        },
+                        {
+                            "items": {
+                                "$ref": "#/$defs/DANJAResourceIdentifier"
                             },
-                            "type": "object"
+                            "type": "array"
                         },
                         {
                             "type": "null"
@@ -182,6 +172,19 @@
                     ],
                     "default": null,
                     "title": "Lid"
+                },
+                "meta": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": true,
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Meta"
                 }
             },
             "required": [

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,7 +1,9 @@
+from typing import Optional, Union
+
 import pytest
 from pydantic import ValidationError
 
-from pydanja import DANJAError, DANJASource
+from pydanja import DANJAError, DANJARelationship, DANJAResourceIdentifier, DANJASource
 
 
 def test_error_with_source():
@@ -13,3 +15,17 @@ def test_error_with_source():
     error = errors[0]
     assert error["type"] == "extra_forbidden"
     assert error["loc"] == ("source", "str")
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        None,
+        [],
+        [DANJAResourceIdentifier(type="type", id="id"), DANJAResourceIdentifier(type="type2", id="id2")],
+        DANJAResourceIdentifier(type="type3", id="id3"),
+    ],
+)
+def test_relationship_data_good(data: Optional[Union[list[DANJAResourceIdentifier], DANJAResourceIdentifier]]) -> None:
+    """Validation passes on correct values."""
+    DANJARelationship.model_validate({"data": data})


### PR DESCRIPTION
As pointed out in issue #6 the relationship data attribute is not an optional dict.
[Ref](https://jsonapi.org/format/#document-resource-object-linkage)

Sorry, about the formatting changes, it's from ruff on autosave.  Let me know if you'd like them undone.

<!-- readthedocs-preview pydanja start -->
----
📚 Documentation preview 📚: https://pydanja--8.org.readthedocs.build/en/8/

<!-- readthedocs-preview pydanja end -->